### PR TITLE
Enhance edit contact and delete contact

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -34,7 +34,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_WORD = "editc";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -32,7 +32,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends Command {
+public class EditContactCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
@@ -60,7 +60,7 @@ public class EditCommand extends Command {
      * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
-    public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+    public EditContactCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
 
@@ -113,12 +113,12 @@ public class EditCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof EditCommand)) {
+        if (!(other instanceof EditContactCommand)) {
             return false;
         }
 
         // state check
-        EditCommand e = (EditCommand) other;
+        EditContactCommand e = (EditContactCommand) other;
         return index.equals(e.index)
                 && editPersonDescriptor.equals(e.editPersonDescriptor);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,7 +12,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteContactCommand;
 import seedu.address.logic.commands.DeleteMeetingCommand;
-import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditContactCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -50,8 +50,8 @@ public class AddressBookParser {
         case AddContactCommand.COMMAND_WORD:
             return new AddContactCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+        case EditContactCommand.COMMAND_WORD:
+            return new EditContactCommandParser().parse(arguments);
 
         case DeleteContactCommand.COMMAND_WORD:
             return new DeleteContactCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditContactCommandParser.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
@@ -24,17 +24,17 @@ import seedu.address.model.tag.Tag;
 
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new EditContactCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditContactCommandParser implements Parser<EditContactCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the EditContactCommand
+     * and returns an EditContactCommand object for execution.
      *
      * @throws ParseException if the user input does not conform the expected format
      */
-    public EditCommand parse(String args) throws ParseException {
+    public EditContactCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_TELEGRAM, PREFIX_TAG);
@@ -44,7 +44,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new
+                    ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditContactCommand.MESSAGE_USAGE), pe);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
@@ -63,10 +64,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(EditContactCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new EditCommand(index, editPersonDescriptor);
+        return new EditContactCommand(index, editPersonDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.UniquePersonList;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.Participant;
 import seedu.address.model.meeting.UniqueMeetingList;
 
 
@@ -107,8 +108,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      * {@code key} must exist in the address book.
      */
     public void removePerson(Contact key) {
-
+        assert hasPerson(key) : "Contact specified does not exist in the contact list";
         persons.remove(key);
+        removeMeetingParticipant(key);
     }
 
     public void sortPerson() {
@@ -151,6 +153,10 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removeMeeting(Meeting key) {
         meetings.remove(key);
+    }
+
+    private void removeMeetingParticipant(Contact key) {
+        meetings.removeMeetingParticipant(new Participant(key));
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -98,9 +98,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
     public void setPerson(Contact target, Contact editedPerson) {
+        assert hasPerson(target) : "Contact specified does not exist in the contact list";
         requireNonNull(editedPerson);
 
         persons.setContact(target, editedPerson);
+        setMeetingParticipant(target, editedPerson);
     }
 
     /**
@@ -145,6 +147,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedMeeting);
 
         meetings.setMeeting(target, editedMeeting);
+    }
+
+    private void setMeetingParticipant(Contact target, Contact editedContact) {
+        meetings.setMeetingParticipant(new Participant(target), new Participant(editedContact));
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -111,6 +111,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Contact key) {
         assert hasPerson(key) : "Contact specified does not exist in the contact list";
+
         persons.remove(key);
         removeMeetingParticipant(key);
     }
@@ -150,7 +151,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     private void setMeetingParticipant(Contact target, Contact editedContact) {
-        meetings.setMeetingParticipant(new Participant(target), new Participant(editedContact));
+        meetings.updateParticipantLists(new Participant(target), new Participant(editedContact));
     }
 
     /**
@@ -162,7 +163,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     private void removeMeetingParticipant(Contact key) {
-        meetings.removeMeetingParticipant(new Participant(key));
+        meetings.removeFromParticipantLists(new Participant(key));
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -67,7 +67,7 @@ public class Meeting {
      * @param editedParticipant the updated participant that will replace {@code target}
      * @return
      */
-    public Meeting setMeetingParticipant(Participant target, Participant editedParticipant) {
+    public Meeting setParticipant(Participant target, Participant editedParticipant) {
         requireAllNonNull(target, editedParticipant);
         assert participants.contains(target) : "The given participant is not participating in this meeting";
 
@@ -83,7 +83,8 @@ public class Meeting {
      * @param toRemove the participant to remove.
      * @return a new meeting instance with the participant removed
      */
-    public Meeting removeMeetingParticipant(Participant toRemove) {
+    public Meeting removeParticipant(Participant toRemove) {
+        requireAllNonNull(toRemove);
         assert participants.contains(toRemove) : "The given participant is not participating in this meeting";
 
         Set<Participant> newParticipants = participants.stream()
@@ -96,7 +97,7 @@ public class Meeting {
      * Returns true if the participant {@code toCheck} is in
      * this meeting's participant list.
      */
-    public boolean hasMeetingParticipant(Participant toCheck) {
+    public boolean hasParticipant(Participant toCheck) {
         return participants.contains(toCheck);
     }
 

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -23,8 +23,8 @@ public class Meeting {
     private final EndTime endTime;
 
     // Data fields
-    private final Set<Participant> participants = new HashSet<Participant>();
-    private final Set<Tag> tags = new HashSet<Tag>();
+    private final Set<Participant> participants = new HashSet<>();
+    private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
@@ -73,6 +73,14 @@ public class Meeting {
                 .filter(p -> !p.isSameParticipant(toRemove))
                 .collect(Collectors.toSet());
         return new Meeting(name, date, startTime, endTime, newParticipants, tags);
+    }
+
+    /**
+     * Returns true if the participant {@code toCheck} is in
+     * this meeting's participant list.
+     */
+    public boolean hasMeetingParticipant(Participant toCheck) {
+        return participants.contains(toCheck);
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -61,13 +61,30 @@ public class Meeting {
     }
 
     /**
+     * Replaces a participant of this meeting with the {@code editedParticipant}.
+     *
+     * @param target the participant to be replaced
+     * @param editedParticipant the updated participant that will replace {@code target}
+     * @return
+     */
+    public Meeting setMeetingParticipant(Participant target, Participant editedParticipant) {
+        requireAllNonNull(target, editedParticipant);
+        assert participants.contains(target) : "The given participant is not participating in this meeting";
+
+        Set<Participant> newParticipants = new HashSet<>(participants);
+        newParticipants.remove(target);
+        newParticipants.add(editedParticipant);
+        return new Meeting(name, date, startTime, endTime, newParticipants, tags);
+    }
+
+    /**
      * Removes a participant from this meeting's participant list
      *
      * @param toRemove the participant to remove.
      * @return a new meeting instance with the participant removed
      */
     public Meeting removeMeetingParticipant(Participant toRemove) {
-        assert participants.contains(toRemove);
+        assert participants.contains(toRemove) : "The given participant is not participating in this meeting";
 
         Set<Participant> newParticipants = participants.stream()
                 .filter(p -> !p.isSameParticipant(toRemove))

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import seedu.address.model.contact.Contact;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -70,7 +69,7 @@ public class Meeting {
     public Meeting removeMeetingParticipant(Participant toRemove) {
         assert participants.contains(toRemove);
 
-        Set<Participant> newParticipants= participants.stream()
+        Set<Participant> newParticipants = participants.stream()
                 .filter(p -> !p.isSameParticipant(toRemove))
                 .collect(Collectors.toSet());
         return new Meeting(name, date, startTime, endTime, newParticipants, tags);

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -6,7 +6,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import seedu.address.model.contact.Contact;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -57,6 +59,21 @@ public class Meeting {
 
     public Set<Participant> getParticipants() {
         return Collections.unmodifiableSet(participants);
+    }
+
+    /**
+     * Removes a participant from this meeting's participant list
+     *
+     * @param toRemove the participant to remove.
+     * @return a new meeting instance with the participant removed
+     */
+    public Meeting removeMeetingParticipant(Participant toRemove) {
+        assert participants.contains(toRemove);
+
+        Set<Participant> newParticipants= participants.stream()
+                .filter(p -> !p.isSameParticipant(toRemove))
+                .collect(Collectors.toSet());
+        return new Meeting(name, date, startTime, endTime, newParticipants, tags);
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/Participant.java
+++ b/src/main/java/seedu/address/model/meeting/Participant.java
@@ -26,6 +26,15 @@ public class Participant {
         return contact.toString();
     }
 
+    public boolean isSameParticipant(Participant other) {
+        if (other == this) {
+            return true;
+        }
+
+        return other != null
+                && other.contact.isSameContact(this.contact);
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/meeting/Participant.java
+++ b/src/main/java/seedu/address/model/meeting/Participant.java
@@ -26,6 +26,11 @@ public class Participant {
         return contact.toString();
     }
 
+    /**
+     * Returns true if this participant's {@code contact} shares the same name and at
+     * least one other identity field as the {@code other} participant's {@code contact}.
+     * This defines a weaker notion of equality between two participants.
+     */
     public boolean isSameParticipant(Participant other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -3,6 +3,7 @@ package seedu.address.model.meeting;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -95,6 +96,15 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         }
 
         internalList.setAll(meetings);
+    }
+
+    public void removeMeetingParticipant(Participant key) {
+        requireNonNull(key);
+        List<Meeting> newMeetings = new ArrayList<>();
+        for (Meeting m : internalList) {
+            newMeetings.add(m.removeMeetingParticipant(key));
+        }
+        setMeetings(newMeetings);
     }
 
     /**

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -3,9 +3,9 @@ package seedu.address.model.meeting;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -99,20 +99,34 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     }
 
     /**
+     * Replaces a participant {@code target} in all meetings it is
+     * participating in with {@code editedParticipant}.
+     *
+     * @param target the participant to be updated
+     * @param editedParticipant the updated participant
+     */
+    public void setMeetingParticipant(Participant target, Participant editedParticipant) {
+        requireAllNonNull(target, editedParticipant);
+        List<Meeting> newMeetings = internalList.stream()
+                .map(existingMeeting -> existingMeeting.hasMeetingParticipant(target)
+                                                ? existingMeeting.setMeetingParticipant(target, editedParticipant)
+                                                : existingMeeting)
+                .collect(Collectors.toList());
+        setMeetings(newMeetings);
+    }
+
+    /**
      * Removes a meeting participant from all meetings it is participating in.
      *
      * @param key the participant to be removed
      */
     public void removeMeetingParticipant(Participant key) {
         requireNonNull(key);
-        List<Meeting> newMeetings = new ArrayList<>();
-        for (Meeting m : internalList) {
-            if (m.hasMeetingParticipant(key)) {
-                newMeetings.add(m.removeMeetingParticipant(key));
-            } else {
-                newMeetings.add(m);
-            }
-        }
+        List<Meeting> newMeetings = internalList.stream()
+                .map(existingMeeting -> existingMeeting.hasMeetingParticipant(key)
+                                        ? existingMeeting.removeMeetingParticipant(key)
+                                        : existingMeeting)
+                .collect(Collectors.toList());
         setMeetings(newMeetings);
     }
 

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -105,11 +105,11 @@ public class UniqueMeetingList implements Iterable<Meeting> {
      * @param target the participant to be updated
      * @param editedParticipant the updated participant
      */
-    public void setMeetingParticipant(Participant target, Participant editedParticipant) {
+    public void updateParticipantLists(Participant target, Participant editedParticipant) {
         requireAllNonNull(target, editedParticipant);
         List<Meeting> newMeetings = internalList.stream()
-                .map(existingMeeting -> existingMeeting.hasMeetingParticipant(target)
-                                                ? existingMeeting.setMeetingParticipant(target, editedParticipant)
+                .map(existingMeeting -> existingMeeting.hasParticipant(target)
+                                                ? existingMeeting.setParticipant(target, editedParticipant)
                                                 : existingMeeting)
                 .collect(Collectors.toList());
         setMeetings(newMeetings);
@@ -118,13 +118,13 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     /**
      * Removes a meeting participant from all meetings it is participating in.
      *
-     * @param key the participant to be removed
+     * @param toRemove the participant to be removed
      */
-    public void removeMeetingParticipant(Participant key) {
-        requireNonNull(key);
+    public void removeFromParticipantLists(Participant toRemove) {
+        requireNonNull(toRemove);
         List<Meeting> newMeetings = internalList.stream()
-                .map(existingMeeting -> existingMeeting.hasMeetingParticipant(key)
-                                        ? existingMeeting.removeMeetingParticipant(key)
+                .map(existingMeeting -> existingMeeting.hasParticipant(toRemove)
+                                        ? existingMeeting.removeParticipant(toRemove)
                                         : existingMeeting)
                 .collect(Collectors.toList());
         setMeetings(newMeetings);

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -107,7 +107,11 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         requireNonNull(key);
         List<Meeting> newMeetings = new ArrayList<>();
         for (Meeting m : internalList) {
-            newMeetings.add(m.removeMeetingParticipant(key));
+            if (m.hasMeetingParticipant(key)) {
+                newMeetings.add(m.removeMeetingParticipant(key));
+            } else {
+                newMeetings.add(m);
+            }
         }
         setMeetings(newMeetings);
     }

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -98,6 +98,11 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         internalList.setAll(meetings);
     }
 
+    /**
+     * Removes a meeting participant from all meetings it is participating in.
+     *
+     * @param key the participant to be removed
+     */
     public void removeMeetingParticipant(Participant key) {
         requireNonNull(key);
         List<Meeting> newMeetings = new ArrayList<>();

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -61,8 +61,8 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    public static final EditCommand.EditPersonDescriptor DESC_AMY;
-    public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditContactCommand.EditPersonDescriptor DESC_AMY;
+    public static final EditContactCommand.EditPersonDescriptor DESC_BOB;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -28,9 +28,9 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ * Contains integration tests (interaction with the Model) and unit tests for EditContactCommand.
  */
-public class EditCommandTest {
+public class EditContactCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -38,14 +38,14 @@ public class EditCommandTest {
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Contact editedPerson = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_PERSON, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editContactCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -59,26 +59,26 @@ public class EditCommandTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
-        EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editContactCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Contact editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editContactCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
@@ -87,24 +87,24 @@ public class EditCommandTest {
 
         Contact personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Contact editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(EditContactCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editContactCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
         Contact firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editContactCommand, model, EditContactCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
@@ -113,19 +113,19 @@ public class EditCommandTest {
 
         // edit person in filtered list into a duplicate in address book
         Contact personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditContactCommand editContactCommand = new EditContactCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editContactCommand, model, EditContactCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditContactCommand editContactCommand = new EditContactCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editContactCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     /**
@@ -139,19 +139,19 @@ public class EditCommandTest {
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditContactCommand editContactCommand = new EditContactCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editContactCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditContactCommand standardCommand = new EditContactCommand(INDEX_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditContactCommand commandWithSameValues = new EditContactCommand(INDEX_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -164,10 +164,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditContactCommand(INDEX_SECOND_PERSON, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditContactCommand(INDEX_FIRST_PERSON, DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
@@ -12,7 +12,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddContactCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteContactCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -58,9 +58,9 @@ public class AddressBookParserTest {
     public void parseCommand_edit() throws Exception {
         Contact person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
-        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+        EditContactCommand command = (EditContactCommand) parser.parseCommand(EditContactCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        assertEquals(new EditContactCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditContactCommandParserTest.java
@@ -34,8 +34,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Name;
 import seedu.address.model.contact.Phone;
@@ -45,14 +45,14 @@ import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 
 
-public class EditCommandParserTest {
+public class EditContactCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditContactCommand.MESSAGE_USAGE);
 
-    private EditCommandParser parser = new EditCommandParser();
+    private EditContactCommandParser parser = new EditContactCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -60,7 +60,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", EditContactCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
@@ -116,7 +116,7 @@ public class EditCommandParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withTelegram(VALID_TELEGRAM_AMY)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -128,7 +128,7 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -139,31 +139,31 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
         userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
         descriptor = new EditPersonDescriptorBuilder().withTelegram(VALID_TELEGRAM_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -178,7 +178,7 @@ public class EditCommandParserTest {
                 .withEmail(VALID_EMAIL_BOB).withTelegram(VALID_TELEGRAM_BOB)
                 .withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -189,7 +189,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
@@ -197,7 +197,7 @@ public class EditCommandParserTest {
                 + PHONE_DESC_BOB;
         descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTelegram(VALID_TELEGRAM_BOB).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditContactCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -207,7 +207,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditContactCommand expectedCommand = new EditContactCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Name;

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddContactCommand;
-import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditContactCommand.EditPersonDescriptor;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.tag.Tag;
 


### PR DESCRIPTION
Closes #97, closes #98 

- Enhance editing and deleting of contacts to automatically update participant lists
- Change EditCommand's command word to `editc`
- Refactor EditCommand to EditContactCommand and similarly for its parser